### PR TITLE
[Fix]Itemモデルのgenresアソシエーションを修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
     has_many :order_details
-    belongs_to :genre
+    has_many :genres
     has_many :cart_items
     has_many :customers, through: :cart_items
     


### PR DESCRIPTION
Itemモデルのジャンルアソシエーションをbelongs_toからhas_manyに修正しました。