### PR TITLE
顧客商品一覧ページににジャンル毎の絞り込み機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -199,6 +201,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.7-aarch64-linux)
     sqlite3 (1.6.7-x86_64-linux)
     thor (1.2.2)
     tilt (2.3.0)
@@ -233,6 +236,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/stylesheets/public/genres.scss
+++ b/app/assets/stylesheets/public/genres.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/genres controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/genres_controller.rb
+++ b/app/controllers/public/genres_controller.rb
@@ -1,0 +1,2 @@
+class Public::GenresController < ApplicationController
+end

--- a/app/controllers/public/genres_controller.rb
+++ b/app/controllers/public/genres_controller.rb
@@ -1,12 +1,14 @@
 class Public::GenresController < ApplicationController
   def fliter
     if params[:id] == '0'
-      # 全商品のジャンルが選ばれた場合
+      # 全商品のリンクが選択された場合
       @items = Item.all
+      @genre_name = '商品'
       
     else
-      # その他のジャンルが選ばれた場合
+      # その他のジャンルのリンクが選択選ばれた場合
       @items = Item.where(genre_id: params[:id])
+      @genre_name = Genre.find(params[:id]).name
     end
   end
 end

--- a/app/controllers/public/genres_controller.rb
+++ b/app/controllers/public/genres_controller.rb
@@ -1,2 +1,12 @@
 class Public::GenresController < ApplicationController
+  def fliter
+    if params[:id] == '0'
+      # 全商品のジャンルが選ばれた場合
+      @items = Item.all
+      
+    else
+      # その他のジャンルが選ばれた場合
+      @items = Item.where(genre_id: params[:id])
+    end
+  end
 end

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -3,6 +3,7 @@ class Public::ItemsController < ApplicationController
     def index
         @items = Item.all
         @genres = Genre.all
+        @genre_name = '商品'
     end
     
     def show

--- a/app/helpers/public/genres_helper.rb
+++ b/app/helpers/public/genres_helper.rb
@@ -1,0 +1,2 @@
+module Public::GenresHelper
+end

--- a/app/views/public/genres/_list.erb
+++ b/app/views/public/genres/_list.erb
@@ -1,0 +1,23 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>ジャンル検索</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="mb-3 px-4">
+        <%= link_to '全商品', public_genres_filter_path(0), remote: true %>
+      </td>
+    </tr>
+    <% @genres.each do |genre| %>
+      <tr>
+        <td class="mb-3 px-4">
+          <%= link_to public_genres_filter_path(genre.id), remote: true do %>
+            <%= genre.name %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/public/genres/fliter.js.erb
+++ b/app/views/public/genres/fliter.js.erb
@@ -1,0 +1,1 @@
+$('#item-list').html("<%= j( render 'public/items/list' ) %>");

--- a/app/views/public/items/_list.html.erb
+++ b/app/views/public/items/_list.html.erb
@@ -1,0 +1,14 @@
+<div>
+    <h4>商品一覧 全<%= @items.count %>件</h4>
+</div>
+<div class="row row-cols-4">
+    <% @items.each do |item| %>
+    <div class="d-block">
+        <%= image_tag item.image, size: "150x100" %>
+        </br>
+        <%= link_to item.name, public_item_path(item.id) %>
+        </br>
+        ¥<%= item.price %>
+    </div>
+    <% end %>
+</div>

--- a/app/views/public/items/_list.html.erb
+++ b/app/views/public/items/_list.html.erb
@@ -1,5 +1,5 @@
 <div>
-    <h4>商品一覧 全<%= @items.count %>件</h4>
+    <h4><%= @genre_name %>一覧 全<%= @items.count %>件</h4>
 </div>
 <div class="row row-cols-4">
     <% @items.each do |item| %>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,30 +1,11 @@
 <div class="container">
     <div class="row mt-5 mb-3 justify-content-between">
         <div class="col-md-3">
-            <!--ジャンル一覧表をrenderで追加予定-->
+            <%= render 'public/genres/list' %>
         </div>
         
-        <div class="col-md-8">
-            <div>
-                <h4>商品一覧 全<%= @items.count %>件</h4>
-            </div>
-            <div class="row row-cols-4">
-                <% @items.each do |item| %>
-                <div class="d-block">
-                <%= image_tag item.image, size: "150x100" %>
-                </br>
-                <%= link_to item.name, public_item_path(item.id) %>
-                </br>
-                ¥<%= item.price %>
-                </div>
-                <% end %>
-            </div>
-            </div>
+        <div id="item-list" class="col-md-8">
+            <%= render 'public/items/list' %>
         </div>
-        
-        
     </div>
-    
-    
-    
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     resources :items
     resources :orders, only: [:index]
     resources :application
+    get 'genres/filter/:id' => 'genres#fliter', as: :genres_filter
   end
   
   namespace :admin do

--- a/test/controllers/public/genres_controller_test.rb
+++ b/test/controllers/public/genres_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::GenresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- [Add] public/genresコントローラーを作成
- [Add] genresコントローラーのルーティングを設定
- [Add] ジャンル検索の部分テンプレートを作成
- [Refactor] 商品一覧を部分テンプレート化
- [Feat] genreコントローラーのfilterアクションを非同期で実装
- [Feat] 商品一覧の見出しを非同期毎に選択ジャンル名に変化させる