### PR TITLE
AdminモデルとGenreモデルへのバリデーション設定忘れを解決

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,4 +3,6 @@ class Admin < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,2 +1,3 @@
 class Genre < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
 end


### PR DESCRIPTION
- admin.rbに「validates :email, presence: true, uniqueness: true」を記述
- genre.rbに「validates :name, presence: true, uniqueness: true」を記述