### PR TITLE
トップページの新着投稿の表示投稿順を修正

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -3,11 +3,9 @@ class Public::HomesController < ApplicationController
     @genres = Genre.all
     
     # メインビジュアル用の商品をランダムで3つ取得
-    @rand_items = Item.where(is_active: true)
-    @rand_items.sample(5)
+    @rand_items = Item.where(is_active: true).sample(5)
 
     # 新規作成順に並び替えて、10件のItemモデルを取得
-    @new_items = Item.where(is_active: true)
-    @new_items.order(created_at: :desc).limit(10)
+    @new_items = Item.order(created_at: :desc).where(is_active: true).limit(10)
   end
 end


### PR DESCRIPTION
新しく商品を作成しても、トップページの新着投稿にラインナップされないバグを修正！
許してください！