### PR TITLE
管理者用のヘッダーナビゲーションを表示

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,9 +1,7 @@
 class Admin::HomesController < ApplicationController
+    before_action :authenticate_admin!
     
     def index
         @orders = Order.all
     end 
-    
-   
-    
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
     <div class="mt-3 mr-5 text-white">
     ようこそ、<%= current_customer.last_name %>さん!
     </div>
-    <div class="d-flex flex-row-reverse"> 
+    <div class="d-flex flex-row"> 
       <div>
         <%= link_to "マイページ", customer_path,class: "btn btn-danger" %>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,41 +14,40 @@
 
   <body>
     <header>
-    <nav class="navbar navbar-expand-lg navbar-light bg-danger justify-content-end">  
-    <% if customer_signed_in? %>
-    <div class="mt-3 mr-5 text-white">
-    ようこそ、<%= current_customer.last_name %>さん!
-    </div>
-    <div class="d-flex flex-row"> 
-      <div>
-        <%= link_to "マイページ", customer_path,class: "btn btn-danger" %>
-      </div>
-      <div>
-        <%= link_to "商品一覧", items_path,class: "btn btn-danger" %>
-      </div>
-      <div>
-        <%= link_to "カート", cart_items_path,class: "btn btn-danger" %>
-      </div>
-      <div>
-        <%= link_to "ログアウト", destroy_customer_session_path, method: :delete,class: "btn btn-danger" %>
-      </div>
-    <% else %>
-      <div>
-        <%= link_to "About", about_path,class: "btn btn-danger" %>
-      </div>
-      <div>
-        <%= link_to "商品一覧", items_path,class: "btn btn-danger" %>
-      </div>
-      <div>
-        <%= link_to "新規登録", new_customer_registration_path,class: "btn btn-danger" %>
-      </div>
-      <div>
-        <%= link_to "ログイン", new_customer_session_path,class: "btn btn-danger" %>
-      </div>
-    </div>  
-    <% end %>
-  </nav>
-  </header>
+      <nav class="navbar navbar-expand-lg navbar-light bg-danger justify-content-end">  
+        <% if customer_signed_in? %>
+          <div class="mt-3 mr-5 text-white">
+            ようこそ、<%= current_customer.last_name %>さん!
+          </div>
+          <div>
+            <%= link_to "マイページ", customer_path,class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "商品一覧", items_path,class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "カート", cart_items_path,class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "ログアウト", destroy_customer_session_path, method: :delete,class: "btn btn-danger" %>
+          </div>
+        <% else %>
+          <div>
+            <%= link_to "About", about_path,class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "商品一覧", items_path,class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "新規登録", new_customer_registration_path,class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "ログイン", new_customer_session_path,class: "btn btn-danger" %>
+          </div>
+        <% end %>
+      </nav>
+    </header>
+    
     <%= render 'layouts/flash' %>
 
     <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,23 @@
   <body>
     <header>
       <nav class="navbar navbar-expand-lg navbar-light bg-danger justify-content-end">  
-        <% if customer_signed_in? %>
+        <% if request.fullpath.include?("/admin") && admin_signed_in? %>
+          <div>
+            <%= link_to "商品一覧", admin_items_path, class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "会員一覧", admin_customers_path, class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "注文履歴一覧", admin_orders_path, class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "ジャンル一覧", admin_genres_path, class: "btn btn-danger" %>
+          </div>
+          <div>
+            <%= link_to "ログアウト", destroy_admin_session_path, method: :delete, class: "btn btn-danger" %>
+          </div>
+        <% elsif customer_signed_in? %>
           <div class="mt-3 mr-5 text-white">
             ようこそ、<%= current_customer.last_name %>さん!
           </div>
@@ -47,7 +63,7 @@
         <% end %>
       </nav>
     </header>
-    
+
     <%= render 'layouts/flash' %>
 
     <%= yield %>


### PR DESCRIPTION
- 管理者ページかつ管理者ログインしている場合、管理者用のヘッダーナビゲーションを表示
- 細かい修正
  - ヘッダーナビゲーションの項目が逆さになっていた点を修正
  - 管理者ログインしていない状態でも、管理者トップ画面にアクセス出来てしまう点を修正